### PR TITLE
modal width and height adjust for mobile device

### DIFF
--- a/js/zui.js
+++ b/js/zui.js
@@ -374,8 +374,8 @@ $.fn.modal = function(opts){
     mcw.removeClass('scroll').height('auto')
 
     var
-    w = $(window).width()
-    ,h = $(window).height()
+    w = screen.width()
+    ,h = screen.height()
     ,ww = defaults.width
     ,hh = mcw.height()
     ,ht = t.height()


### PR DESCRIPTION
standard for mobile device

I use this modal on android webview.
it could not make modal height if use $(window).height.
so I change this to screen.height can get mobile device' height.
